### PR TITLE
Rm print_tty;

### DIFF
--- a/src/bin/zhifeng_line_str_security_util/main.rs
+++ b/src/bin/zhifeng_line_str_security_util/main.rs
@@ -23,7 +23,7 @@ use chacha20poly1305::{
 use sha3::{digest::generic_array::GenericArray, Digest, Sha3_256};
 
 use zhifeng_security_util::{
-    pop_newline_from_string_mut_ref, print_tty, read_line_in_private, ByteString, SafeString,
+    pop_newline_from_string_mut_ref, read_line_in_private, ByteString, SafeString,
 };
 
 fn read_secret_key_line_in_private() -> Result<GenericArray<u8, U32>, Box<dyn Error>> {
@@ -54,10 +54,10 @@ fn encrypt(cipher: &ChaCha20Poly1305) -> Result<(), Box<dyn Error>> {
     let cipher_bytestring = ByteString::new(cipher_bytes);
     let nonce_bytestring = ByteString::try_from(nonce_bytes.bytes())?;
 
-    print_tty(format!(
+    println!(
         "[(Encrypted)](#{}{})\n",
         nonce_bytestring, cipher_bytestring
-    ))?;
+    );
 
     Ok(())
 }
@@ -83,7 +83,7 @@ fn decrypt(cipher: &ChaCha20Poly1305) -> Result<(), Box<dyn Error>> {
         }
     };
 
-    print_tty(format!("{}\n", String::from_utf8(plaintext_bytes)?))?;
+    println!("{}", String::from_utf8(plaintext_bytes)?);
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use safe_string::SafeString;
 
 mod util;
 
-pub use util::{pop_newline_from_string_mut_ref, print_tty};
+pub use util::pop_newline_from_string_mut_ref;
 
 #[path = "read_line_in_private/read_line_in_private.rs"]
 mod read_line_in_private;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,3 @@
-// The Code Was Adapted from Rust Crate "rtoolbox = 0.0.2"
-
 pub fn pop_newline_from_string_mut_ref(string_mut_ref: &mut String) {
     if string_mut_ref.ends_with('\n') {
         string_mut_ref.pop();
@@ -8,71 +6,3 @@ pub fn pop_newline_from_string_mut_ref(string_mut_ref: &mut String) {
         string_mut_ref.pop();
     }
 }
-
-#[cfg(target_family = "wasm")]
-mod wasm {
-    use std::io::Write;
-
-    /// Displays a message on the STDOUT
-    pub fn print_tty(prompt: impl ToString) -> std::io::Result<()> {
-        let mut stdout = std::io::stdout();
-        write!(stdout, "{}", prompt.to_string().as_str())?;
-        stdout.flush()?;
-        Ok(())
-    }
-}
-
-#[cfg(target_family = "unix")]
-mod unix {
-    use std::io::Write;
-
-    /// Displays a message on the TTY
-    pub fn print_tty(prompt: impl ToString) -> std::io::Result<()> {
-        let mut stream = std::fs::OpenOptions::new().write(true).open("/dev/tty")?;
-        stream
-            .write_all(prompt.to_string().as_str().as_bytes())
-            .and_then(|_| stream.flush())
-    }
-}
-
-#[cfg(target_family = "windows")]
-mod windows {
-    use std::io::Write;
-    use std::os::windows::io::FromRawHandle;
-    use windows_sys::core::PCSTR;
-    use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE};
-    use windows_sys::Win32::Storage::FileSystem::{
-        CreateFileA, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
-    };
-
-    /// Displays a message on the TTY
-    pub fn print_tty(prompt: impl ToString) -> std::io::Result<()> {
-        let handle = unsafe {
-            CreateFileA(
-                b"CONOUT$\x00".as_ptr() as PCSTR,
-                GENERIC_READ | GENERIC_WRITE,
-                FILE_SHARE_READ | FILE_SHARE_WRITE,
-                std::ptr::null(),
-                OPEN_EXISTING,
-                0,
-                INVALID_HANDLE_VALUE,
-            )
-        };
-        if handle == INVALID_HANDLE_VALUE {
-            return Err(std::io::Error::last_os_error());
-        }
-
-        let mut stream = unsafe { std::fs::File::from_raw_handle(handle as _) };
-
-        stream
-            .write_all(prompt.to_string().as_str().as_bytes())
-            .and_then(|_| stream.flush())
-    }
-}
-
-#[cfg(target_family = "unix")]
-pub use unix::print_tty;
-#[cfg(target_family = "wasm")]
-pub use wasm::print_tty;
-#[cfg(target_family = "windows")]
-pub use windows::print_tty;


### PR DESCRIPTION
I found the previous `print_tty` function behaves differently on different Windows systems and vanilla `println!` also works. So I switched to use the latter one.